### PR TITLE
Allow spaces before Babel source markers in bodies

### DIFF
--- a/test/verb-test.el
+++ b/test/verb-test.el
@@ -684,6 +684,15 @@
                              "hello"))
   (should (string= (oref aux :body) "<something/>\nhello"))
 
+  ;; Removes src block markers even when indented
+  (setq aux (text-as-spec-nl "  GET example.com"
+        		     "  Accept: text"
+        		     ""
+        		     "  #+begin_src xml"
+                             "  <something/>"
+                             "  #+end_src"))
+  (should (string= (oref aux :body) "  <something/>\n"))
+
   (setq aux (text-as-spec-nl "GET example.com"
 			     "Accept: text"
 			     ""

--- a/verb.el
+++ b/verb.el
@@ -2232,7 +2232,7 @@ METADATA."
       ;; features that depend on specific content types (e.g JSON,
       ;; XML, etc.). Here we delete the source block delimiters so
       ;; that they are not included in the actual request.
-      (delete-matching-lines "^#\\+\\(begin\\|end\\)_src")
+      (delete-matching-lines "^[[:blank:]]*#\\+\\(begin\\|end\\)_src")
 
       ;; Expand code tags in the rest of the buffer (if any)
       (save-excursion


### PR DESCRIPTION
I indent my source blocks, but the current regex doesn't recognise this and doesn't strip the Babel source block delimiters in this case.