### PR TITLE
fix pretty print for map with `t` key value

### DIFF
--- a/test/server.py
+++ b/test/server.py
@@ -33,6 +33,10 @@ async def headers_test(request: Request) -> HTTPResponse:
 async def basic_json(request: Request) -> HTTPResponse:
     return response.json({"hello": "world", "foo": True}, sort_keys=True)
 
+@app.route("/keywords-json")
+async def basic_json(request: Request) -> HTTPResponse:
+    return response.json({"t": True}, sort_keys=True)
+
 
 @app.route("/error-400")
 async def error_400(request: Request) -> HTTPResponse:

--- a/test/test.org
+++ b/test/test.org
@@ -13,6 +13,8 @@ get /basic
 
 ** basic-json
 get /basic-json
+** keywords-json
+get /keywords-json
 ** stored
 :properties:
 :Verb-Store: foobar

--- a/test/verb-test.el
+++ b/test/verb-test.el
@@ -1966,6 +1966,13 @@
 				  "{\n  \"foo\": true,\n  \"hello\": \"world\"\n}"))
 		 (should (eq major-mode 'js-mode)))))
 
+(ert-deftest test-server-keywords-json-pretty ()
+  (let ((verb-json-max-pretty-print-size 99999))
+    (server-test "keywords-json"
+		 (should (string= (buffer-string)
+				  "{\n  \"t\": true\n}"))
+		 (should (eq major-mode 'js-mode)))))
+
 (ert-deftest test-server-basic-json-mode ()
   (let ((verb-json-use-mode #'html-mode))
     (server-test "basic-json"

--- a/verb.el
+++ b/verb.el
@@ -1454,7 +1454,8 @@ non-nil, do not add the command to the kill ring."
            (or verb-json-max-pretty-print-size 0))
     (unwind-protect
         (unless (zerop (buffer-size))
-          (let ((json-pretty-print-max-secs 0))
+          (let ((json-pretty-print-max-secs 0)
+                (json-key-type 'string))
             (buffer-disable-undo)
             (json-pretty-print-buffer)
             ;; "Use" `json-pretty-print-max-secs' here to avoid


### PR DESCRIPTION
json-pretty-print-buffer fails if there is a map with `t` as one of the keys. Changing the key type to string solves the issue.

I am not sure why this is required and not done by json-pretty-print-buffer by default.