### PR TITLE
show path column in the response buffer header

### DIFF
--- a/verb.el
+++ b/verb.el
@@ -1483,7 +1483,8 @@ non-nil, do not add the command to the kill ring."
   (let ((status-line (oref response status))
         (elapsed (oref response duration))
         (headers (oref response headers))
-        (bytes (oref response body-bytes)))
+        (bytes (oref response body-bytes))
+        (path (oref (oref (oref response request) url) filename)))
     (concat
      (or status-line "No Response")
      " | "
@@ -1498,7 +1499,8 @@ non-nil, do not add the command to the kill ring."
                      bytes)))
        (format " | %s byte%s"
                (file-size-human-readable value)
-               (if (= value 1) "" "s"))))))
+               (if (= value 1) "" "s")))
+     " | " path)))
 
 (cl-defmethod verb-request-spec-url-to-string ((rs verb-request-spec))
   "Return RS's url member as a string if it is non-nil."


### PR DESCRIPTION
When sending multiple requests, it becomes difficult to quickly differentiate which response belongs to what request. I think it would be nice to have request path at the header, so it looks more like this:

"HTTP/1.1 200  | 1.755s | application/json | 1.2k bytes | /api/testing/something"