### PR TITLE
Feature: Add Verb-Prelude property to load config files for requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ setup-tests:  ## Install everything required for testing (Python dependencies).
 	python3 --version
 	test -d $(ENV) || python3 -m venv $(ENV)
 	$(ACTIVATE) && \
-	pip install -U pip wheel && \
+	pip install -U pip wheel setuptools && \
 	pip install -r test/requirements-dev.txt
 
 test: ## Run all ERT tests (set SELECTOR to specify only one).

--- a/test/env.el
+++ b/test/env.el
@@ -1,0 +1,2 @@
+(verb-set-var "foo" "hello")
+(verb-set-var "bar" "world")

--- a/test/env.json
+++ b/test/env.json
@@ -1,0 +1,4 @@
+{
+  "foo": "hello",
+  "bar": "world"
+}

--- a/test/init.el
+++ b/test/init.el
@@ -25,6 +25,7 @@
 
 ;; Set up Verb
 (setq verb-auto-kill-response-buffers 3)
+(setq verb-suppress-load-unsecure-prelude-warning t)
 
 ;; Keybindings
 (with-eval-after-load 'org (define-key org-mode-map (kbd "C-c C-r") verb-command-map))

--- a/test/test.org
+++ b/test/test.org
@@ -150,6 +150,16 @@ Content-Type: application/xml
 
 bar2
 {{(verb-part)}}
+** prelude-elisp
+:properties:
+:Verb-Prelude: env.el
+:end:
+get /echo-args?{{(verb-var foo)}}={{(verb-var bar)}}
+** prelude-json
+:properties:
+:Verb-Prelude: env.json
+:end:
+get /echo-args?{{(verb-var foo)}}={{(verb-var bar)}}
 * connection-fail-port
 # Valid host but invalid port
 get http://localhost:1234/test

--- a/test/verb-test.el
+++ b/test/verb-test.el
@@ -2226,6 +2226,15 @@
   (server-test "multipart"
                (should (string= (buffer-string) "OK"))))
 
+(ert-deftest test-server-request-prelude-elisp ()
+  (let ((verb-suppress-load-unsecure-prelude-warning t))
+    (server-test "prelude-elisp"
+               (should (string= (buffer-string) "hello=world")))))
+
+(ert-deftest test-server-request-prelude-json ()
+  (server-test "prelude-json"
+               (should (string= (buffer-string) "hello=world"))))
+
 (ert-deftest test-server-response-big5 ()
   (server-test "response-big5"
                (should (coding-system-equal buffer-file-coding-system 'chinese-big5-unix))


### PR DESCRIPTION
* Add ability to set, load and parse external config files into verb-var's
* Update tests to validate properties and requests
* Update README.md for user documentation on the feature
* Minor updates to test harness
* Rebase of previous commit with sync-up of origin/main
